### PR TITLE
fix: maintain backward compatibility with previous event number prefs

### DIFF
--- a/src/modules/edit.ts
+++ b/src/modules/edit.ts
@@ -7,6 +7,21 @@ import { closeWindow, isWindowAlive } from "../utils/window";
 
 export { editAction };
 
+const actionEventOptionKeys: Array<keyof typeof ActionEventTypes> = [
+  "none",
+  "createItem",
+  "openFile",
+  "closeTab",
+  "createAnnotation",
+  "createNote",
+  "appendAnnotation",
+  "appendNote",
+  "changeAnnotationColor",
+  "programStartup",
+  "mainWindowLoad",
+  "mainWindowUnload",
+];
+
 async function editAction(currentKey?: string) {
   let edited = false;
   currentKey = currentKey || addon.data.actions.selectedKey;
@@ -73,7 +88,7 @@ async function editAction(currentKey?: string) {
             "data-bind": "event",
             "data-prop": "value",
           },
-          children: getEnumKeys(ActionEventTypes).map((key) => ({
+          children: actionEventOptionKeys.map((key) => ({
             tag: "option",
             properties: {
               innerHTML: getString(`prefs-action-event-${key}`),

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -24,27 +24,30 @@ export {
 };
 
 enum ActionEventTypes {
-  "none",
-  "createItem",
-  "openFile",
-  "closeTab",
-  "createAnnotation",
-  "createNote",
-  "appendAnnotation",
-  "appendNote",
-  "changeAnnotationColor",
-  "programStartup",
-  "mainWindowLoad",
-  "mainWindowUnload",
+  // Keep numeric values stable: these are persisted in prefs.
+  none = 0,
+  createItem = 1,
+  openFile = 2,
+  closeTab = 3,
+  createAnnotation = 4,
+  createNote = 5,
+  appendAnnotation = 6,
+  appendNote = 7,
+  programStartup = 8,
+  mainWindowLoad = 9,
+  mainWindowUnload = 10,
+  // New values should be appended only.
+  changeAnnotationColor = 11,
 }
 
 enum ActionOperationTypes {
-  "none",
-  "add",
-  "remove",
-  "toggle",
-  "script",
-  "triggerAction",
+  // Keep numeric values stable: these are persisted in prefs.
+  none = 0,
+  add = 1,
+  remove = 2,
+  toggle = 3,
+  script = 4,
+  triggerAction = 5,
 }
 
 type ActionShowInMenu =


### PR DESCRIPTION
after 175b1ae

If there are 8-10 key values for events (programStartup, mainWindowLoad/UnLoad) in the user's current list or backup file, they will be misplaced after 175b1ae. This PR has fixed this issue.

But if the user has modified the key values of 8-11 in version v2.5.0, after this PR, the user still needs to manually change back to the correct event.